### PR TITLE
[STEP-17] kafka consumer, producer 연동 및 테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,10 @@ dependencies {
     // Jackson
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.0")
 
+    // kafka
+    implementation("org.springframework.kafka:spring-kafka")
+    testImplementation("org.testcontainers:kafka:1.19.3")
+
 
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,41 @@ services:
       - ./data/redis:/data
     command: redis-server --appendonly yes  # 데이터 지속성을 위한 AOF 설정
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "22181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  kafka-ui:
+    container_name: kafka-ui
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8989:8080"    # http://localhost:8989 으로 접속
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:9092
+      - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
+    depends_on:
+      - kafka
+      - zookeeper
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/domain/order/OrderEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/OrderEvent.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.domain.order;
+
+import kr.hhplus.be.server.domain.support.DomainEvent;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class OrderEvent {
+    public record Completed(
+            Long orderId,
+            Long userId,
+            Long paymentId,
+            BigDecimal amount,
+            LocalDateTime paidAt,
+            LocalDateTime createdAt
+    ) implements DomainEvent {
+        public static Completed from(Order order) {
+            return new Completed(
+                    order.getId(),
+                    order.getUser().getId(),
+                    order.getId(),
+                    order.getPaymentAmount(),
+                    order.getCreatedAt(),
+                    LocalDateTime.now()
+            );
+        }
+
+        @Override
+        public String eventType() {
+            return this.getClass().getSimpleName();
+        }
+
+        @Override
+        public Long entityId() {
+            return orderId;
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infra/test/KafkaPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infra/test/KafkaPublisher.java
@@ -1,0 +1,19 @@
+package kr.hhplus.be.server.infra.test;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaPublisher {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void publish(String topic, String message) {
+        kafkaTemplate.send(topic, message);
+        log.info("메시지 발행: {}", message);
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/test/KafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/test/KafkaConsumer.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.interfaces.test;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class KafkaConsumer {
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void consume(String message) {
+        log.info("메시지 수신: {}", message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,16 @@ spring:
           connectionPoolSize: 10
           connectTimeout: 10000
           timeout: 3000
+  kafka:
+    bootstrap-servers: localhost:29092
+    consumer:
+      group-id: my-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 springdoc:
   api-docs:
     enabled: true

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -3,62 +3,77 @@ package kr.hhplus.be.server;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
 class TestcontainersConfiguration {
 
-	public static final MySQLContainer<?> MYSQL_CONTAINER;
-	public static final GenericContainer<?> REDIS_CONTAINER;
+    public static final MySQLContainer<?> MYSQL_CONTAINER;
+    public static final GenericContainer<?> REDIS_CONTAINER;
+    public static final KafkaContainer KAFKA_CONTAINER;
 
-	private static final int REDIS_PORT = 6379;
 
-	static {
-		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-			.withDatabaseName("hhplus")
-			.withUsername("test")
-			.withPassword("test");
-		MYSQL_CONTAINER.start();
+    private static final int REDIS_PORT = 6379;
 
-		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
-		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
-		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+    static {
+        MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
+                .withDatabaseName("hhplus")
+                .withUsername("test")
+                .withPassword("test");
+        MYSQL_CONTAINER.start();
 
-		// JPA 설정 추가
-		System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
-		System.setProperty("spring.jpa.show-sql", "true");
+        System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
+        System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
+        System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
 
-		// Redis 컨테이너 설정
-		REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:latest"))
-				.withExposedPorts(REDIS_PORT)
-				.withCommand("redis-server", "--appendonly", "yes");
-		REDIS_CONTAINER.start();
+        // JPA 설정 추가
+        System.setProperty("spring.jpa.hibernate.ddl-auto", "create");
+        System.setProperty("spring.jpa.show-sql", "true");
 
-		// Redis 설정
-		String redisHost = REDIS_CONTAINER.getHost();
-		Integer redisMappedPort = REDIS_CONTAINER.getMappedPort(REDIS_PORT);
-		System.setProperty("spring.data.redis.host", redisHost);
-		System.setProperty("spring.data.redis.port", String.valueOf(redisMappedPort));
+        // Redis 컨테이너 설정
+        REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:latest"))
+                .withExposedPorts(REDIS_PORT)
+                .withCommand("redis-server", "--appendonly", "yes");
+        REDIS_CONTAINER.start();
 
-		// Redisson 설정
-		System.setProperty("spring.redis.redisson.config",
-				String.format("singleServerConfig:\n" +
-						"  address: \"redis://%s:%d\"\n" +
-						"  connectionMinimumIdleSize: 1\n" +
-						"  connectionPoolSize: 10\n" +
-						"  connectTimeout: 10000\n" +
-						"  timeout: 3000", redisHost, redisMappedPort));
+        // Redis 설정
+        String redisHost = REDIS_CONTAINER.getHost();
+        Integer redisMappedPort = REDIS_CONTAINER.getMappedPort(REDIS_PORT);
+        System.setProperty("spring.data.redis.host", redisHost);
+        System.setProperty("spring.data.redis.port", String.valueOf(redisMappedPort));
 
-	}
+        // Redisson 설정
+        System.setProperty("spring.redis.redisson.config",
+                String.format("singleServerConfig:\n" +
+                        "  address: \"redis://%s:%d\"\n" +
+                        "  connectionMinimumIdleSize: 1\n" +
+                        "  connectionPoolSize: 10\n" +
+                        "  connectTimeout: 10000\n" +
+                        "  timeout: 3000", redisHost, redisMappedPort));
 
-	@PreDestroy
-	public void preDestroy() {
-		if (MYSQL_CONTAINER.isRunning()) {
-			MYSQL_CONTAINER.stop();
-		}
-		if (REDIS_CONTAINER.isRunning()) {
-			REDIS_CONTAINER.stop();
-		}
-	}
+        // Kafka 컨테이너 설정
+        KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
+                .withReuse(false);
+        KAFKA_CONTAINER.start();
+
+        // Kafka 설정
+        System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+        System.setProperty("spring.kafka.consumer.auto-offset-reset", "earliest");
+        System.setProperty("spring.kafka.consumer.group-id", "test-group");
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        if (MYSQL_CONTAINER.isRunning()) {
+            MYSQL_CONTAINER.stop();
+        }
+        if (REDIS_CONTAINER.isRunning()) {
+            REDIS_CONTAINER.stop();
+        }
+        if (KAFKA_CONTAINER.isRunning()) {
+            KAFKA_CONTAINER.stop();
+        }
+    }
 }

--- a/src/test/java/kr/hhplus/be/server/infra/KafkaIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/infra/KafkaIntegrationTest.java
@@ -1,0 +1,38 @@
+package kr.hhplus.be.server.infra;
+
+import kr.hhplus.be.server.infra.test.KafkaPublisher;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertTrue;
+
+@SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
+class KafkaIntegrationTest {
+    @Autowired
+    private KafkaPublisher kafkaPublisher;
+
+    @Test
+    void 카프카_퍼블리셔로_메시지_발행되면_카프카_컨슈머가_수신하고_로그에서_확인된다(CapturedOutput output) {
+        // given
+        String message = "카프카 메세지 발행된다~~";
+
+        // when
+        kafkaPublisher.publish("test-topic", message);
+
+        // then : log.info 출력 확인
+        await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertTrue(output.toString().contains("메시지 발행: " + message));
+                    assertTrue(output.toString().contains("메시지 수신: " + message));
+                });
+    }
+}


### PR DESCRIPTION
### **커밋 링크**

1. [kafka consumer, producer 연동 및 테스트](https://github.com/ynyejn/e-commerce/commit/6200685c367350eec5a365d5ddb9dd622051b3e0)


---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1 : Awaitility와 CapturedOutput 이용하여 로그로 발행, 수신 확인했슴다 더 좋은방법 있을까요?

  
---
### **이번주 KPT 회고**

### Keep
- 코드 꼼꼼히 짜려고 노력 .. 그래도 선착순쿠폰은 나눠보았다..

### Problem
- 막판이라 해이해지는 중 .. 오더파사드도 나눠볼 수 있었을텐데 하지못햇다....

### Try
- 유종의 미 거두기~!